### PR TITLE
fix: findBestPlacement not choosing best when target has different height and width

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,11 +195,11 @@ export class Position {
 				hiddenWidth = box.right - container.width;
 			}
 			// if one of the hidden dimensions is 0 but the other is > 0
-			// we want to have a positive area, so setting the null one to target dimension
+			// we want to have a positive area, so setting the null one to 1
 			if (hiddenHeight && !hiddenWidth) {
-				hiddenWidth = (target as HTMLElement).offsetWidth;
+				hiddenWidth = 1;
 			} else if (hiddenWidth && !hiddenHeight) {
-				hiddenHeight = (target as HTMLElement).offsetHeight;
+				hiddenHeight = 1;
 			}
 			const area = (target as HTMLElement).offsetHeight * (target as HTMLElement).offsetWidth;
 			const hiddenArea = hiddenHeight * hiddenWidth;


### PR DESCRIPTION
A bit of context:
making this change as using the target width and height might false the calculations as they are not always the same value which means if i have a 20x200  target...and the bottom placement is going offscreen for 100px height while the top placement is going offscreen for 20px width...the algorithm would still prefer bottom as the visible area calculated would be bigger than the top placement. To fix this i'm always assigning the same value to the null hidden dimension.

@zvonimirfras can you review this?